### PR TITLE
docs: add Canadian student internship resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 - [List of Opportunities in Tech for All Class Years](https://github.com/Julian048/CS-Programs-Fellowships-Insights)
 - [List of Open-Source Fellowships](https://github.com/deepanshu1422/List-Of-Open-Source-Internships-Programs)
 - [List of Undergraduate Research Internships](https://github.com/himahuja/Research-Internships-for-Undergraduates)
+- [Hanzilla Jobs](https://jobs.hanzilla.co/internships/) - Daily-updated Canadian student internship, co-op, new-grad, junior, and entry-level jobs across tech, finance, engineering, business, sciences, and more.
 
 ## **Website & Autofill Extension**
 


### PR DESCRIPTION
## Summary
- adds Hanzilla Jobs to the Useful Lists section as a Canada-specific companion resource
- links directly to the internships/co-ops page for students looking beyond US-only early-talent programs
- keeps the description factual: daily-updated Canadian student/recent-grad roles across internships, co-ops, new grad, junior, and entry-level jobs

## Why
This complements the existing underclassmen internship/program list for Canadian students who also need a current Canada-wide job board while applying to programs.
