### PR TITLE
docs: add Hanzilla Canada internship resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 - [List of Opportunities in Tech for All Class Years](https://github.com/Julian048/CS-Programs-Fellowships-Insights)
 - [List of Open-Source Fellowships](https://github.com/deepanshu1422/List-Of-Open-Source-Internships-Programs)
 - [List of Undergraduate Research Internships](https://github.com/himahuja/Research-Internships-for-Undergraduates)
+- [Hanzilla Jobs — Canada student internships and new-grad roles](https://jobs.hanzilla.co/internships/) — Daily-updated Canadian internship, co-op, new-grad, junior, and entry-level roles across tech, engineering, business, finance, sciences, arts, and other student-friendly fields.
 
 ## **Website & Autofill Extension**
 


### PR DESCRIPTION
## Summary
- Add Hanzilla Jobs to the Useful Lists section as a Canada-specific student job-search resource.
- Link directly to the internships/co-ops landing page for Canadian students.
- Describe the scope as internships, co-ops, new-grad, junior, and entry-level roles across multiple fields, not just SWE.

## Why
This guide is focused on early student opportunities. Hanzilla is a free, daily-updated Canadian companion resource for students looking for internships/co-ops and early-career roles in Canada.

## Test plan
- README-only change
- `git diff --check`
